### PR TITLE
copy binary to /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN cd /go/src/github.com/openshift/pod-checkpointer-operator && make build
 FROM centos:7
 COPY manifests /manifests
 
-COPY --from=builder /go/src/github.com/openshift/pod-checkpointer-operator/pod-checkpointer-operator /pod-checkpointer-operator
-
-ENTRYPOINT /pod-checkpointer-operator
+COPY --from=builder /go/src/github.com/openshift/pod-checkpointer-operator/pod-checkpointer-operator /usr/bin/pod-checkpointer-operator
 
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
Need to copy `pod-checkpointer-operator` to location included in $PATH for this to work
https://github.com/openshift/pod-checkpointer-operator/blob/master/manifests/0000_05_pod-checkpointer-operator_04-deployment.yaml#L32

Right now I get
```
        message: |
          container create failed: container_linux.go:336: starting container process caused "exec: \"pod-checkpointer-operator\": executable file not found in $PATH"
        reason: CreateContainerError
```