### PR TITLE
dockerfile: move binary to local bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN cd /go/src/github.com/openshift/pod-checkpointer-operator && make build
 FROM centos:7
 COPY manifests /manifests
 
-COPY --from=builder /go/src/github.com/openshift/pod-checkpointer-operator/pod-checkpointer-operator /usr/bin/pod-checkpointer-operator
+COPY --from=builder /go/src/github.com/openshift/pod-checkpointer-operator/pod-checkpointer-operator /usr/local/bin/pod-checkpointer-operator
 
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
Consistent with operator-sdk build command.